### PR TITLE
Release the flush lock if there is nothing to do.

### DIFF
--- a/lib/resty/logger/socket.lua
+++ b/lib/resty/logger/socket.lua
@@ -209,6 +209,7 @@ local function _flush()
         if debug then
             ngx_log(DEBUG, "do not need to flush:", log_buffer_index)
         end
+        _flush_unlock()
         return true
     end
 


### PR DESCRIPTION
Fixes the issue that all logging stops the first time _flush is called
and there is nothing to send.
