### PR TITLE
Retry quickly if we're shutting down.

### DIFF
--- a/lib/resty/logger/socket.lua
+++ b/lib/resty/logger/socket.lua
@@ -134,9 +134,7 @@ local function _connect()
         end
 
         -- ngx.sleep use seconds to count time
-        if exiting then
-            ngx_sleep(0)
-        else
+        if not exiting then
             ngx_sleep(retry_interval / 1000)
         end
 
@@ -244,9 +242,7 @@ local function _flush()
         end
 
         -- ngx.sleep use seconds to count time
-        if exiting then
-            ngx_sleep(0)
-        else
+        if not exiting then
             ngx_sleep(retry_interval / 1000)
         end
 


### PR DESCRIPTION
Not sure if ngx_sleep(0) was the intention?

I presume this gives other code a chance to run before we try again. Please let me know if I have this wrong.
