### PR TITLE
fix _connect function return value

### DIFF
--- a/lib/resty/logger/socket.lua
+++ b/lib/resty/logger/socket.lua
@@ -121,7 +121,7 @@ local function _connect()
         if debug then
             ngx_log(DEBUG, "previous connect not finished")
         end
-        return true
+        return nil, "previous connect not finished"
     end
 
     connected = false


### PR DESCRIPTION
While connneting to the log server, the return value 'true' can not be used as a socket.
