### PR TITLE
fix cloudflare/lua-resty-logger-socket/issues/29

### DIFF
--- a/lib/resty/logger/socket.lua
+++ b/lib/resty/logger/socket.lua
@@ -223,7 +223,7 @@ local function _do_flush()
     end
 
     if (sock_type ~= 'udp') then
-        ok, err = sock:setkeepalive(0, pool_size)
+        ok, err = sock:setkeepalive(timeout, pool_size)
         if not ok then
             return nil, err
         end


### PR DESCRIPTION
the msg cannot send to logstash when `sock:setkeepalive` timeout is zero.

fix https://github.com/cloudflare/lua-resty-logger-socket/issues/29